### PR TITLE
refactor(smallest): use Math.min

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,4 @@
 'use strict'
-
-var toArray = require('to-array')
-
 module.exports = function smallest (values) {
-  if (!Array.isArray(values)) {
-    values = toArray(arguments)
-  }
-  return values.slice().sort(order)[0]
-}
-
-function order (a, b) {
-  return a - b
+  return Math.min.apply(Math, Array.isArray(values) ? values : arguments)
 }


### PR DESCRIPTION
This would just be `Math.min` if you didn't have the feature for passing an array. If the native `Math.min` function is slow then you can use this algorithm

``` javascript
function smallest () {
 var values = Array.isArray(arguments[0]) ? arguments[0] : arguments;
 for (var i = 0, max; i < values.length; i++) {
   max = max < values[i] ? max : values[i];
 }
 return max;
}
```
